### PR TITLE
Adding quit password field resolves #7.

### DIFF
--- a/classes/campla_client.php
+++ b/classes/campla_client.php
@@ -143,8 +143,11 @@ class campla_client {
         $examination['end'] = self::unixtimetoiso8601($formdata->quizclosesunixtime);
         $examination['sebBrowserExamKey'] = settings_provider::get_campla_quizallowedbrowserexamkey($formdata->cmid);
         $examination['securityLevel'] = (int) $formdata->securitylevel;
-        $examination['quitPassword'] = settings_provider::get_campla_quizquitpassword($formdata->cmid);
-
+        if ((int) $formdata->securitylevel === 5) {
+            $examination['quitPassword'] = $formdata->quitpassword;
+        } else {
+            $examination['quitPassword'] = '';
+        }
         $module = [];
         $module['name'] = $formdata->coursename;
 

--- a/classes/form/sendtocamplaform.php
+++ b/classes/form/sendtocamplaform.php
@@ -247,6 +247,9 @@ class sendtocamplaform extends \core_form\dynamic_form {
         $mform->addElement('text', 'quizcloses', get_string('quizcloses', 'mod_quiz'));
         $mform->setType('quizcloses', PARAM_NOTAGS);
 
+        $mform->addElement('text', 'quitpassword', get_string('quitpassword', 'quizaccess_campla'));
+        $mform->setType('quitpassword', PARAM_NOTAGS);
+
         $securityleveloptions = [
             '1' => get_string('securitylevellernstick', 'quizaccess_campla'),
             '5' => get_string('securitylevelseb', 'quizaccess_campla'),
@@ -272,7 +275,7 @@ class sendtocamplaform extends \core_form\dynamic_form {
         $mform->addElement('hidden', 'cmid');
         $mform->setType('cmid', PARAM_INT);
 
-        $mform->freeze(['quizurl', 'quizopens', 'quizcloses']);
+        $mform->freeze(['quizurl', 'quizopens', 'quizcloses', 'quitpassword']);
 
         if (empty($this->_ajaxformdata['hidebuttons'])) {
             $this->add_action_buttons(true, get_string('submitlabel', 'quizaccess_campla'));
@@ -304,6 +307,8 @@ class sendtocamplaform extends \core_form\dynamic_form {
             $quizclosesunixtime = 0;
         }
 
+        $quitpassword = \quizaccess_campla\settings_provider::get_campla_quizquitpassword($cmid);
+
         $securitylevel = get_config('quizaccess_campla', 'securitylevel') ?? 5;
 
         $this->set_data([
@@ -316,6 +321,7 @@ class sendtocamplaform extends \core_form\dynamic_form {
             'quizcloses' => $quizcloses,
             'quizopensunixtime' => $quizopensunixtime,
             'quizclosesunixtime' => $quizclosesunixtime,
+            'quitpassword' => $quitpassword,
             'securitylevel' => $securitylevel,
             'cmid' => $cmid,
             'hidebuttons' => $this->optional_param('hidebuttons', false, PARAM_BOOL),

--- a/classes/settings_provider.php
+++ b/classes/settings_provider.php
@@ -181,14 +181,22 @@ class settings_provider {
     public static function get_campla_quizquitpassword(int $cmid): string {
         global $DB;
         if ($cmid === 0) {
-            return '';
+            return 'Invalid – no correct cmid provided.';
         }
         $installedplugins = core_plugin_manager::instance()->get_installed_plugins('quizaccess');
         if (!(isset($installedplugins['seb']))) {
             // SEB quizaccess plugin could be disabled or not installed.
-            return '';
+            return self::generatepassword();
         }
-        return $DB->get_field_sql('SELECT quitpassword FROM {quizaccess_seb_quizsettings} WHERE cmid = ?', [$cmid]) ?? '';
+        $actualpassword = $DB->get_field_sql(
+            'SELECT quitpassword FROM {quizaccess_seb_quizsettings} WHERE cmid = ?',
+            [$cmid],
+        );
+        if ($actualpassword === '') {
+            return self::generatepassword();
+        } else {
+            return $actualpassword;
+        }
     }
 
     /**
@@ -336,5 +344,22 @@ class settings_provider {
             $keys[$i] = strtolower($key);
         }
         return $keys;
+    }
+
+    /**
+     * This helper method generates a 8 character password without ambiguous characters that could be mistaken.
+     *
+     * @return string, a 8 character password without ambiguous lI1O0.
+     */
+    private static function generatepassword(): string {
+        $password = '';
+        $characters = '23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+        $maxindex = strlen($characters) - 1;
+
+        for ($i = 0; $i < 8; $i++) {
+            $password .= $characters[random_int(0, $maxindex)];
+        }
+
+        return $password;
     }
 }

--- a/lang/en/quizaccess_campla.php
+++ b/lang/en/quizaccess_campla.php
@@ -41,6 +41,7 @@ $string['invalidtokenresponse'] = 'Invalid response from JWT token request.';
 $string['na'] = 'N/A';
 $string['pluginname'] = 'CAMPLA exam configuration';
 $string['privacy:metadata'] = 'The CAMPLA quiz access plugin does not store any personal data.';
+$string['quitpassword'] = 'Quit password';
 $string['quizname'] = 'Quiz name';
 $string['quizowner'] = 'Quiz owner';
 $string['quizurl'] = 'Quiz URL';


### PR DESCRIPTION
This is also adding a field to see the quit password.
If one is added already in the Safe Exam Browser settings, that one will be taken.
Otherwise, a new one is generated.

Note the password is only sent to CAMPLA given the Security Level is "Safe Exam Browser".

<img width="807" height="613" alt="image" src="https://github.com/user-attachments/assets/8473c8a8-8790-4753-bd39-65e0885fea76" />
